### PR TITLE
renaming endpoint

### DIFF
--- a/src/skills/skill.controller.ts
+++ b/src/skills/skill.controller.ts
@@ -18,8 +18,8 @@ import { Prisma } from "@prisma/client";
 export class SkillMgmtController {
     constructor(private skillService: SkillMgmtService) {}
 
-    @Get("/skill/")
-    listUsers(@Param("repositoryId") dto: SkillSearchDto) {
+    @Get("/getAllSkills/")
+    getAllSkills() {
         return this.skillService.loadAllSkills();
     }
 


### PR DESCRIPTION
/skill/
->    listUsers(@Param("repositoryId") dto: SkillSearchDto)
changed to :
/getAllSkills/
->     getAllSkills()