### PR TITLE
ci: remove dev and release tags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,10 +113,7 @@ pipeline {
 
                 stage('Deploy') {
                     when {
-                        anyOf {
-                            branch 'dev'
-                            branch 'main'
-                        }
+                        branch 'main'
                     }
                     steps {
                         stagingDeploy env.REMOTE_UPDATE_SCRIPT
@@ -125,10 +122,7 @@ pipeline {
 
                 stage('Publish Swagger Clients') {
                     when {
-                        allOf {
-                            branch 'main'
-                            expression { packageJson.isNewVersion() }
-                        }
+                        buildingTag()
                     }
                     options {
                         timeout(time: 200, unit: 'SECONDS')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                                   sh 'touch testfile.txt'
                                 }
                             } catch(err) {
-                                if (env.BRANCH_NAME == 'master') {
+                                if (env.BRANCH_NAME == 'main') {
                                     error('Stopping build on master branch due to test failures.')
                                 } else {
                                     unstable('Tests failed, but continuing build on development branches.')


### PR DESCRIPTION
In this PR, the release process has been updated, including significant changes such as the **removal of the development branch** from the continuous integration pipeline and the **enforcement of successful builds on the main branch** contingent upon passing tests.

For the updated release instructions:
- New tags will be automatically detected by Jenkins at the specified URL.
- A project administrator on Jenkins is required to initiate the build process manually.
- The version number is extracted from the `package.json` file.
- A Docker image is then released.
- The name of the tag does not impact the release.


Docker Tags:
- `latest` is reserved for the latest released docker version (is automatically used when running a build on a tag)
- `unstable` now represents the latest commits on `main` and is used for the demo instance